### PR TITLE
Update h5ad-to-arrow dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm project directory
+.idea/

--- a/containers/h5ad-to-arrow/context/requirements-freeze.txt
+++ b/containers/h5ad-to-arrow/context/requirements-freeze.txt
@@ -8,13 +8,16 @@ conda-package-handling==1.6.0
 cryptography==2.7
 h5py==2.10.0
 idna==2.8
+importlib-metadata==1.6.0
 natsort==6.2.0
 numpy==1.17.4
+packaging==20.3
 pandas==0.25.3
 pyarrow==0.15.1
 pycosat==0.6.3
 pycparser==2.19
 pyOpenSSL==19.0.0
+pyparsing==2.4.7
 PySocks==1.7.1
 python-dateutil==2.8.1
 pytz==2019.3
@@ -24,3 +27,4 @@ scipy==1.3.3
 six==1.13.0
 tqdm==4.36.1
 urllib3==1.24.2
+zipp==3.1.0

--- a/containers/h5ad-to-arrow/context/requirements-freeze.txt
+++ b/containers/h5ad-to-arrow/context/requirements-freeze.txt
@@ -1,4 +1,4 @@
-anndata==0.6.22.post1
+anndata==0.7.1
 asn1crypto==1.0.1
 certifi==2019.11.28
 cffi==1.12.3
@@ -6,7 +6,7 @@ chardet==3.0.4
 conda==4.7.12
 conda-package-handling==1.6.0
 cryptography==2.7
-h5py==2.9.0
+h5py==2.10.0
 idna==2.8
 natsort==6.2.0
 numpy==1.17.4

--- a/containers/h5ad-to-arrow/context/requirements.txt
+++ b/containers/h5ad-to-arrow/context/requirements.txt
@@ -1,3 +1,3 @@
-anndata==0.6.22.post1
+anndata==0.7.1
 pyarrow==0.15.1
-h5py==2.9.0 # anndata fails on some inputs: https://github.com/hubmapconsortium/portal-containers/issues/1
+h5py==2.10.0

--- a/h5ad-to-arrow.cwl
+++ b/h5ad-to-arrow.cwl
@@ -6,7 +6,7 @@ class: CommandLineTool
 baseCommand: ['python', '/main.py', '--output_dir', '.', '--input_dir']
 hints:
   DockerRequirement:
-    dockerPull: hubmap/portal-container-h5ad-to-arrow:0.0.1
+    dockerPull: hubmap/portal-container-h5ad-to-arrow:0.0.2
 inputs:
   input_directory:
     type: Directory


### PR DESCRIPTION
Issue #1 has been resurrected by an update to the Salmon RNA-seq pipeline. Fix this by bumping `anndata` to 0.7.1 and `h5py` to 2.10.0.