### PR TITLE
Updated the version number on the wrong CWL.

### DIFF
--- a/ome-tiff-offsets.cwl
+++ b/ome-tiff-offsets.cwl
@@ -6,7 +6,7 @@ class: CommandLineTool
 baseCommand: ['python', '/main.py', '--output_dir', 'output_offsets', '--input_dir']
 hints:
   DockerRequirement:
-    dockerPull: hubmap/portal-container-ome-tiff-offsets:0.0.2
+    dockerPull: hubmap/portal-container-ome-tiff-offsets:0.0.3
 inputs:
   input_directory:
     type: Directory


### PR DESCRIPTION
I updated the version number from 0.0.2 to 0.0.3 on the wrong CWL. It should have been the offsets CWL and I updated it on the tiler CWL.

This PR fixes that issue by updating the version number on the right file.