### PR TITLE
Restrict files matched by anndata-to-ui-manifest.json to limit indexed files

### DIFF
--- a/anndata-to-ui-manifest.json
+++ b/anndata-to-ui-manifest.json
@@ -1,11 +1,11 @@
 [
   {
-    "pattern": "anndata-zarr/secondary_analysis.zarr",
+    "pattern": "anndata-zarr/secondary_analysis.zarr/(.*)\\.zgroup",
     "description": "AnnData Zarr store for storing and visualizing single cell sequencing outputs of UMAP/clustering analysis.",
     "edam_ontology_term": "EDAM_1.24.format_2333"
   },
   {
-    "pattern": "anndata-zarr/scvelo_annotated.zarr",
+    "pattern": "anndata-zarr/scvelo_annotated.zarr/(.*)\\.zgroup",
     "description": "AnnData Zarr store for storing and visualizing single cell sequencing outputs of velocity analysis.",
     "edam_ontology_term": "EDAM_1.24.format_2333"
   }

--- a/sprm-to-anndata-manifest.json
+++ b/sprm-to-anndata-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-    "pattern": "anndata-zarr/(.*)\\.zarr",
+    "pattern": "anndata-zarr/(.*)\\.zarr/(.*)\\.zgroup",
     "description": "AnnData Zarr store for storing and visualizing SPRM outputs.",
     "edam_ontology_term": "EDAM_1.24.format_2333"
   }


### PR DESCRIPTION
The pattern component of anndata-to-ui-manifest.json was matching on all files in the desired directories, causing an impractical number of files to be indexed.  This update changes the regex to only match on the .zgroup files.