### PR TITLE
Azimuth annotations in processed JSON files

### DIFF
--- a/containers/h5ad-to-arrow/context/main.py
+++ b/containers/h5ad-to-arrow/context/main.py
@@ -73,8 +73,8 @@ def h5ad_to_json(h5ad_file, **kwargs):
             "factors": {
                 "Leiden Cluster": str(int(v['leiden'])),
                 **({
-                    "Cell Type Prediction": str(v[PREDICTED_ASCT_CELLTYPE]),
-                    "Cell Type Prediction Score": v[PREDICTED_ASCT_CELLTYPE_SCORE]
+                    "Predicted ASCT Cell Type": str(v[PREDICTED_ASCT_CELLTYPE]),
+                    "Predicted ASCT Cell Type Score": v[PREDICTED_ASCT_CELLTYPE_SCORE]
                 } if adata_is_annotated else {})
             }
         }

--- a/containers/h5ad-to-arrow/context/main.py
+++ b/containers/h5ad-to-arrow/context/main.py
@@ -63,6 +63,7 @@ def h5ad_to_json(h5ad_file, **kwargs):
     df = adata.obs
     df["umap_x"] = adata.obsm["X_umap"].T[0]
     df["umap_y"] = adata.obsm["X_umap"].T[1]
+    df["leiden"] = df["leiden"].astype('uint8')
     df_items = df.T.to_dict().items()
 
     adata_is_annotated = has_cell_type_annotations(adata)
@@ -84,10 +85,10 @@ def h5ad_to_json(h5ad_file, **kwargs):
     with open(umap_json, 'w') as f:
         f.write(pretty_json_umap)
 
-    leiden_clusters = sorted(df['leiden'].unique().astype('uint8'))
+    leiden_clusters = sorted(df['leiden'].unique())
 
     if adata_is_annotated:
-        predicted_cell_types = sorted(df[PREDICTED_ASCT_CELLTYPE].unique().astype(str))
+        predicted_cell_types = sorted(df[PREDICTED_ASCT_CELLTYPE].unique())
     else:
         predicted_cell_types = None
     id_to_factors = {
@@ -97,8 +98,8 @@ def h5ad_to_json(h5ad_file, **kwargs):
         },
         **({
             'Predicted ASCT Cell Type': {
-                'map': [str(predicted_cell_type) for predicted_cell_type in predicted_cell_types],
-                'cells': { k: v[PREDICTED_ASCT_CELLTYPE] for (k,v) in df_items }
+                'map': predicted_cell_types,
+                'cells': { k: predicted_cell_types.index(v[PREDICTED_ASCT_CELLTYPE]) for (k,v) in df_items }
             }
         } if adata_is_annotated else {})
     }

--- a/containers/h5ad-to-arrow/context/main.py
+++ b/containers/h5ad-to-arrow/context/main.py
@@ -26,7 +26,7 @@ def h5ad_to_arrow(h5ad_file, arrow_file):
     leiden = adata.obs['leiden'].to_numpy().astype('uint8')
     index = adata.obs.index
 
-    # TODO: condition on is_annotated
+    # Only use the cell type predictions if they are available in the AnnData file.
     adata_is_annotated = has_cell_type_annotations(adata)
     if adata_is_annotated:
         predicted_cell_type = adata.obs[PREDICTED_ASCT_CELLTYPE].astype(str)


### PR DESCRIPTION
While the JSON files are no longer used in the Vitessce visualizations in the HuBMAP portal (instead the Zarr store is used), the JSON files are still available in the list of files to download.

This PR adds the Azimuth-generated ASCT cell type annotations to those output files.