### PR TITLE
Cast factors indices to int in h5ad-to-arrow

### DIFF
--- a/containers/h5ad-to-arrow/context/main.py
+++ b/containers/h5ad-to-arrow/context/main.py
@@ -94,7 +94,7 @@ def h5ad_to_json(h5ad_file, **kwargs):
     id_to_factors = {
         'Leiden Cluster': {
             'map': [str(cluster) for cluster in leiden_clusters],
-            'cells': { k: v['leiden'] for (k,v) in df_items }
+            'cells': { k: int(v['leiden']) for (k,v) in df_items }
         },
         **({
             'Predicted ASCT Cell Type': {


### PR DESCRIPTION
I found this bug while checking out the JSON files after my change. Without this, the indices in the JSON files can be float rather than int.