### PR TITLE
Changed cwlversion for h5ad-to-arrow container

### DIFF
--- a/h5ad-to-arrow.cwl
+++ b/h5ad-to-arrow.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 # TODO: Make main.py executable?
 baseCommand: ['python', '/main.py', '--output_dir', './output', '--input_dir']


### PR DESCRIPTION
Some files with spaces in their names were throwing error when processed via the `h5ad-to-arrow` pipeline, this PR updates the cwlTool version to avoid such error. 
I did not get an error without the `-relax-path-checks` flag when testing 