### PR TITLE
Updated sprm-to-json docker version

### DIFF
--- a/sprm-to-json.cwl
+++ b/sprm-to-json.cwl
@@ -6,7 +6,7 @@ class: CommandLineTool
 baseCommand: ['python', '/main.py', '--output_dir', './output_json', '--input_dir']
 hints:
   DockerRequirement:
-    dockerPull: hubmap/portal-container-sprm-to-json:0.0.5
+    dockerPull: hubmap/portal-container-sprm-to-json:0.0.6
 inputs:
   input_directory:
     type: Directory


### PR DESCRIPTION
The docker version for this container on [hub](https://hub.docker.com/repository/docker/hubmap/portal-container-sprm-to-json/general) was already `0.0.5`, not sure why. 