### PR TITLE
Fix zip-zarr manifest pattern

### DIFF
--- a/object-by-analyte-to-ui-manifest.json
+++ b/object-by-analyte-to-ui-manifest.json
@@ -1,6 +1,6 @@
 [
   {
-    "pattern": "mudata-zarr/*.zarr.zip",
+    "pattern": "mudata-zarr/(.*)\\.zarr\\.zip",
     "description": "MuData Zarr store for storing and visualizing object by analyte data.",
     "edam_ontology_term": "EDAM_1.24.format_3987"
   },


### PR DESCRIPTION
The previous `*.zarr.zip` pattern isn't picking up the outputs properly; this matches the known working pattern in the sprm outputs.